### PR TITLE
add some test cases (work on tmp_folder)

### DIFF
--- a/conans/test/client/tools/net_test.py
+++ b/conans/test/client/tools/net_test.py
@@ -1,26 +1,42 @@
 # coding=utf-8
 
-import unittest
 import os
+import shutil
+import tempfile
+import unittest
 
+from conans.client.tools import chdir
 from conans.client.tools import net
+from conans.errors import ConanException
 
 
 class ToolsNetTest(unittest.TestCase):
 
-    test_file_name_auth = "readme.txt"
-    test_file_name_anonymous = "1KB.zip"
-
-    def tearDown(self):
-
-        if os.path.exists(self.test_file_name_auth):
-            os.remove(self.test_file_name_auth)
-
-        if os.path.exists(self.test_file_name_anonymous):
-            os.remove(self.test_file_name_anonymous)
+    def run(self, *args, **kwargs):
+        self.tmp_folder = tempfile.mkdtemp()
+        try:
+            with chdir(self.tmp_folder):
+                super(ToolsNetTest, self).run(*args, **kwargs)
+        finally:
+            shutil.rmtree(self.tmp_folder)
 
     def test_ftp_auth(self):
-        net.ftp_download("test.rebex.net", self.test_file_name_auth, "demo", "password")
+        filename = "/pub/example/readme.txt"
+        net.ftp_download("test.rebex.net", filename, "demo", "password")
+        self.assertTrue(os.path.exists(os.path.basename(filename)))
 
     def test_ftp_anonymous(self):
-        net.ftp_download("speedtest.tele2.net", self.test_file_name_anonymous)
+        filename = "1KB.zip"
+        net.ftp_download("speedtest.tele2.net", filename)
+        self.assertTrue(os.path.exists(os.path.basename(filename)))
+
+    def test_ftp_invalid_path(self):
+        with self.assertRaisesRegexp(ConanException,
+                                     "550 The system cannot find the file specified."):
+            net.ftp_download("test.rebex.net", "invalid-file", "demo", "password")
+        self.assertFalse(os.path.exists("invalid-file"))
+
+    def test_ftp_invalid_auth(self):
+        with self.assertRaisesRegexp(ConanException, "530 User cannot log in."):
+            net.ftp_download("test.rebex.net", "readme.txt", "demo", "invalid")
+        self.assertFalse(os.path.exists("readme.txt"))


### PR DESCRIPTION
Hi! Playing with the tests that you proposed for https://github.com/conan-io/conan/pull/4092 I found one use case that is failing, check this line: https://github.com/efremovd/conan/compare/ftp-download-auth...jgsogo:efremovd-ftp-download-auth?expand=1#diff-3c7937871325b48b30cc01374d2a0cbaR37. Please, consider this PR and let me know if your are going to fix the `invalid-file` issue or if you want me to propose the change.

Also, I've rewritten the test class to use a temp folder and clean it up when everything is finished.

Thanks!! All contributions are more than welcome 👐 
